### PR TITLE
Serializers novos

### DIFF
--- a/paralapraca/serializers.py
+++ b/paralapraca/serializers.py
@@ -73,7 +73,7 @@ class UserInDetailSerializer(serializers.ModelSerializer):
     def get_number_of_likes(self, obj):
         return obj.topiclike_set.count() + obj.commentlike_set.count()
 
-class BetterNameLaterSerializer(serializers.Serializer):
+class UsersByClassSerializer(serializers.Serializer):
     # class Meta:
         # model = CourseStudent
 

--- a/paralapraca/serializers.py
+++ b/paralapraca/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 from paralapraca.models import AnswerNotification, UnreadNotification
 from discussion.serializers import BaseTopicSerializer, BaseCommentSerializer, TopicLikeSerializer, CommentLikeSerializer
-
+from accounts.models import TimtecUser
+from core.models import Course, CourseStudent
 
 class AnswerNotificationSerializer(serializers.ModelSerializer):
 
@@ -36,3 +37,70 @@ class UnreadNotificationSerializer(serializers.ModelSerializer):
     class Meta:
         model = UnreadNotification
         fields = ('id', 'counter', )
+
+
+
+class UserInDetailSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = TimtecUser
+        fields = sorted(('cpf', 'courses', 'date_joined', 'last_login', 'full_name', 'topics_created', 'number_of_likes', 'comments_created'))
+
+    comments_created = serializers.SerializerMethodField()
+    full_name = serializers.SerializerMethodField()
+    topics_created = serializers.SerializerMethodField()
+    number_of_likes = serializers.SerializerMethodField()
+    courses = serializers.SerializerMethodField()
+
+    def get_comments_created(self, obj):
+        return obj.comment_author.count()
+
+    def get_courses(self, obj):
+        needed_stuff = [
+            {'percent_progress': x.percent_progress(),
+             'course_name': x.course.name,
+             'has_certificate': x.can_emmit_receipt(),
+             'class_name': x.get_current_class().name
+            } for x in obj.coursestudent_set.all()]
+        return needed_stuff
+
+    def get_full_name(self, obj):
+        return obj.get_full_name()
+
+    def get_topics_created(self, obj):
+        return obj.topic_author.count()
+
+    def get_number_of_likes(self, obj):
+        return obj.topiclike_set.count() + obj.commentlike_set.count()
+
+class BetterNameLaterSerializer(serializers.Serializer):
+    # class Meta:
+        # model = CourseStudent
+
+        # fields = sorted(('cpf', 'email', 'full_name', 'last_login', 'has_certificate'))
+
+    cpf = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
+    full_name = serializers.SerializerMethodField()
+    last_login = serializers.SerializerMethodField()
+    has_certificate = serializers.SerializerMethodField()
+    percent_progress_by_lesson = serializers.SerializerMethodField()
+
+
+    def get_cpf(self, obj):
+        return obj.user.cpf
+
+    def get_email(self, obj):
+        return obj.user.email
+
+    def get_full_name(self, obj):
+        return obj.user.get_full_name()
+
+    def get_last_login(self, obj):
+        return obj.user.last_login
+
+    def get_has_certificate(self, obj):
+        return obj.can_emmit_receipt()
+
+    def get_percent_progress_by_lesson(self, obj):
+        return obj.percent_progress_by_lesson()

--- a/paralapraca/urls.py
+++ b/paralapraca/urls.py
@@ -2,12 +2,16 @@
 from django.conf.urls import url, include
 from django.views.generic import TemplateView
 from rest_framework import routers
+from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views
 
 router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'answer-notification', views.AnswerNotificationViewSet)
 router.register(r'unread-notification', views.UnreadNotificationViewSet)
+router.register(r'summary', views.SummaryViewSet, base_name='summary')
+router.register(r'users-by-group', views.UsersByGroupViewSet, base_name='users-by-group')
+router.register(r'users-by-class', views.UsersByClassViewSet, base_name='users-by-class')
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name="base.html")),

--- a/paralapraca/views.py
+++ b/paralapraca/views.py
@@ -14,7 +14,7 @@ from paralapraca.models import AnswerNotification, UnreadNotification
 from core.models import Course, CourseStudent
 from collections import Counter
 from accounts.models import TimtecUser
-from paralapraca.serializers import AnswerNotificationSerializer, UnreadNotificationSerializer, UserInDetailSerializer, BetterNameLaterSerializer
+from paralapraca.serializers import AnswerNotificationSerializer, UnreadNotificationSerializer, UserInDetailSerializer, UsersByClassSerializer
 from discussion.models import Comment, CommentLike, Topic, TopicLike
 from rest_pandas import PandasViewSet
 from rest_pandas.renderers import PandasCSVRenderer, PandasJSONRenderer
@@ -183,9 +183,9 @@ class UsersByClassViewSet(PandasViewSet):
             # This is a bit ugly, but should work. There is no (easy) way to directly filter from
             # a function, so I'm getting all the desired IDs, then filtering by the desired IDs
             people_ids = [x.id for x in self.queryset if x.get_current_class().id == int(id)]
-            serializer = BetterNameLaterSerializer(self.queryset.filter(id__in=people_ids), many=True)
+            serializer = UsersByClassSerializer(self.queryset.filter(id__in=people_ids), many=True)
         else:
-            serializer = BetterNameLaterSerializer(self.queryset, many=True)
+            serializer = UsersByClassSerializer(self.queryset, many=True)
         return Response(pd.DataFrame.from_dict(self.transform_data(serializer.data)).set_index('cpf'))
 
     def transform_data(self, data):
@@ -198,5 +198,5 @@ class UsersByClassViewSet(PandasViewSet):
                     coursestudent.update({
                         u'Lição {} - Atividade {} realizada'.format(lesson['name'], activity['name']): activity['done']
                     })
-
+            coursestudent.pop('percent_progress_by_lesson', None)
         return data

--- a/paralapraca/views.py
+++ b/paralapraca/views.py
@@ -11,7 +11,14 @@ from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from paralapraca.models import AnswerNotification, UnreadNotification
-from paralapraca.serializers import AnswerNotificationSerializer, UnreadNotificationSerializer
+from core.models import Course, CourseStudent
+from collections import Counter
+from accounts.models import TimtecUser
+from paralapraca.serializers import AnswerNotificationSerializer, UnreadNotificationSerializer, UserInDetailSerializer, BetterNameLaterSerializer
+from discussion.models import Comment, CommentLike, Topic, TopicLike
+from rest_pandas import PandasViewSet
+from rest_pandas.renderers import PandasCSVRenderer, PandasJSONRenderer
+import pandas as pd
 
 
 ROCKET_CHAT = {
@@ -112,3 +119,84 @@ class UnreadNotificationViewSet(viewsets.ModelViewSet):
             UnreadNotification.objects.create(user=self.request.user)
             queryset = UnreadNotification.objects.filter(user=self.request.user)
         return queryset
+
+class SummaryViewSet(viewsets.ViewSet):
+
+    permission_classes = [IsAuthenticated]
+
+    def list(self, request):
+        statistics_per_course = [
+            {'name': course.name,
+             'user_count': course.coursestudent_set.count(),
+             'user_finished_course_count': [student.can_emmit_receipt() for student in course.coursestudent_set.all()].count(True),
+             'classes': [
+                {'name': klass.name,
+                'user_count': klass.get_students.count(),
+                'certificate_count': [student.can_emmit_receipt() for student in klass.get_students.all()].count(True)
+                } for klass in course.class_set.all()]
+            } for course in Course.objects.all()
+        ]
+        return Response({
+            'user_count': TimtecUser.objects.count(),
+            'total_number_of_topics': Topic.objects.count(),
+            'total_number_of_comments': Comment.objects.count(),
+            'total_number_of_likes': TopicLike.objects.count() + CommentLike.objects.count(),
+            'statistics_per_course': statistics_per_course})
+
+
+class UsersByGroupViewSet(PandasViewSet):
+
+    permission_classes = [IsAuthenticated]
+    renderer_classes = [PandasCSVRenderer, PandasJSONRenderer]
+    queryset = TimtecUser.objects.all()
+
+    def list(self, request, format=None):
+        group = request.query_params.get('group', None)
+        if group is not None:
+            serializer = UserInDetailSerializer(self.queryset.filter(groups__name__iexact=group), many=True)
+        else:
+            serializer = UserInDetailSerializer(self.queryset, many=True)
+        # in order to get the data in the wanted column form, I'll need to make some transformations
+        return Response(self.transform_data(serializer.data))
+
+    def transform_data(self, data):
+        response = []
+        for user in data:
+            for course in user.get('courses'):
+                user.update({
+                    u'{} - progresso'.format(course['course_name']): course['percent_progress'],
+                    u'{} - nome da turma'.format(course['course_name']): course['class_name'],
+                    u'{} - possui certificado'.format(course['course_name']): course['has_certificate']
+                })
+            user.pop('courses', None)
+            response.append(user)
+        return pd.DataFrame.from_dict(response)
+
+class UsersByClassViewSet(PandasViewSet):
+
+    permission_classes = [IsAuthenticated]
+    queryset = CourseStudent.objects.all()
+
+    def list(self, request, format=None):
+        id = request.query_params.get('id', None)
+        if id is not None:
+            # This is a bit ugly, but should work. There is no (easy) way to directly filter from
+            # a function, so I'm getting all the desired IDs, then filtering by the desired IDs
+            people_ids = [x.id for x in self.queryset if x.get_current_class().id == int(id)]
+            serializer = BetterNameLaterSerializer(self.queryset.filter(id__in=people_ids), many=True)
+        else:
+            serializer = BetterNameLaterSerializer(self.queryset, many=True)
+        return Response(pd.DataFrame.from_dict(self.transform_data(serializer.data)).set_index('cpf'))
+
+    def transform_data(self, data):
+        for coursestudent in data:
+            for lesson in coursestudent.get(u'percent_progress_by_lesson', None):
+                coursestudent.update({
+                    u'Lição {} - Progresso'.format(lesson['name']): lesson['progress']
+                })
+                for activity in lesson.get(u'activities', None):
+                    coursestudent.update({
+                        u'Lição {} - Atividade {} realizada'.format(lesson['name'], activity['name']): activity['done']
+                    })
+
+        return data


### PR DESCRIPTION
Serializer Summary, com resumão de tudo

Serializer users-by-group e users-by-class, com filtros opcionais e saída pelo Pandas.

Filtros do users-by-group (os dois opcionais):
fomat=[csv,json]
group=[nome-do-grupo]

Filtros do users-by-class (os dois opcionais):
format=[csv,json]
id=[id-da-turma]

**É necessário colocar o Pandas e o django-rest-pandas nas dependências**