### PR TITLE
Fixed wrong number of certificates

### DIFF
--- a/paralapraca/serializers.py
+++ b/paralapraca/serializers.py
@@ -83,7 +83,7 @@ class UserInDetailSerializer(serializers.ModelSerializer):
         needed_stuff = [
             {'percent_progress': x.percent_progress(),
              'course_name': x.course.name,
-             'has_certificate': x.can_emmit_receipt(),
+             'has_certificate': x.certificate.type == 'certificate',
              'class_name': x.get_current_class().name
             } for x in obj.coursestudent_set.all()]
         return needed_stuff
@@ -124,7 +124,7 @@ class UsersByClassSerializer(serializers.Serializer):
         return obj.user.last_login
 
     def get_has_certificate(self, obj):
-        return obj.can_emmit_receipt()
+        return obj.certificate.type == 'certificate'
 
     def get_percent_progress_by_lesson(self, obj):
         return obj.percent_progress_by_lesson()

--- a/paralapraca/views.py
+++ b/paralapraca/views.py
@@ -137,7 +137,7 @@ class SummaryViewSet(viewsets.ViewSet):
              'classes': [
                 {'name': klass.name,
                  'user_count': klass.get_students.count(),
-                 'certificate_count': [student.can_emmit_receipt() for student in klass.get_students.all()].count(True)
+                 'certificate_count': [cs.certificate.type for cs in klass.get_students.all()].count('certificate')
                 } for klass in course.class_set.all()]
             } for course in Course.objects.all()
         ]


### PR DESCRIPTION
I used the wrong function for counting certificates, the `can_emmit_receipt()` function.
Now I changed to something like `[cs.certificate.type for cs in CourseStudent.Objects.all()].count('certificate')`